### PR TITLE
Failing Ember.assert causes `TypeError: a.each is not a function`

### DIFF
--- a/addon/components/i-check.js
+++ b/addon/components/i-check.js
@@ -7,7 +7,7 @@ export default Ember.Checkbox.extend({
 	setup: function() {
 		var that = this;
 
-		Ember.assert("iCheck has to exist on Ember.$.fn.iCheck", Ember.$.fn.iCheck);
+		Ember.assert("iCheck has to exist on Ember.$.fn.iCheck", !!Ember.$.fn.iCheck);
 
 		var icheck = this.$().iCheck({
 			checkboxClass: 'icheckbox_square-blue',


### PR DESCRIPTION
When using ember-cli-icheck with Ember 1.12 there's a `TypeError: a.each is not a function` caused by `Ember.assert` trying to execute the function. Double negating the function before passing it to `Ember.assert` solves the problem.
