### PR TITLE
Do not import icheck when in fastboot

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,30 +1,30 @@
 'use strict';
 var path = require('path');
 
-
 module.exports = {
-  	name: 'ember-cli-icheck',
+  name: 'ember-cli-icheck',
 
-  	included: function(app) {
-  		this._super.included(app);
+  included: function(app) {
+    this._super.included(app);
 
+    if (!process.env.EMBER_CLI_FASTBOOT) {
       app.import(app.bowerDirectory + '/iCheck/icheck.min.js');
+    }
 
+    app.options = app.options || {}; // Ensures options exists for Scss/Less below
+    let options = app.options['emberCliIcheck'] || {};
+    
+    let skinsPath = path.join(app.bowerDirectory, 'iCheck/skins/');
 
-      app.options = app.options || {}; // Ensures options exists for Scss/Less below
-      let options = app.options['emberCliIcheck'] || {};
-      let skinsPath = path.join(app.bowerDirectory, 'iCheck/skins/');
+    let skins = options.skins || ['square'];
+    let colors = options.colors || ['blue'];
 
-      let skins = options.skins || ['square'];
-      let colors = options.colors || ['blue'];
-
-
-      skins.forEach(skin => {
-        colors.forEach(color => {
-          app.import(path.join(skinsPath, skin + "/" + color + ".css"));
-          app.import(path.join(skinsPath, skin + "/" + color + ".png"), { destDir: 'assets' });
-          app.import(path.join(skinsPath, skin + "/" + color + "@2x.png"), { destDir: 'assets' });
-        });
+    skins.forEach(skin => {
+      colors.forEach(color => {
+        app.import(path.join(skinsPath, skin + "/" + color + ".css"));
+        app.import(path.join(skinsPath, skin + "/" + color + ".png"), { destDir: 'assets' });
+        app.import(path.join(skinsPath, skin + "/" + color + "@2x.png"), { destDir: 'assets' });
       });
-  	}
+    });
+  }
 };


### PR DESCRIPTION
ember-cli 2.13+ serves files with fastboot by default, icheck breaks the build if imported in fastboot